### PR TITLE
calculate ancestry proportions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2021"
 
 [dependencies]
 demes = { version =  ">0.2.1,<0.3.0", git = "https://github.com/molpopgen/demes-rs" }
+ndarray = "0.15.4"
 thiserror = "~1"


### PR DESCRIPTION
Each time the graph state is update:

* process pulses/migrations so that
  we can obtain ancestry proportions
  for each child deme.
