### PR TITLE
Improve API safety.

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -638,9 +638,12 @@ impl ForwardGraph {
         self.graph.num_demes()
     }
 
-    pub fn ancestry_proportions(&self, child_deme: usize) -> Option<&[f64]> {
+    pub fn ancestry_proportions(&self, offspring_deme: usize) -> Option<&[f64]> {
+        if offspring_deme >= self.num_demes_in_model() {
+            return None;
+        }
         if !self.child_demes.is_empty() {
-            let start = child_deme * self.child_demes.len();
+            let start = offspring_deme * self.child_demes.len();
             let stop = start + self.child_demes.len();
             Some(&self.ancestry_proportions.as_slice().unwrap()[start..stop])
         } else {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -58,6 +58,11 @@ fn iterate_all_generations(graph: &mut demes_forward::ForwardGraph) -> ModelFirs
                 assert_eq!(parental_deme_sizes.len(), graph.num_demes_in_model());
                 assert_eq!(selfing_rates.len(), graph.num_demes_in_model());
                 assert_eq!(cloning_rates.len(), graph.num_demes_in_model());
+
+                // Stress-test that a deme > no. demes in model returns None
+                assert!(graph
+                    .ancestry_proportions(graph.num_demes_in_model())
+                    .is_none());
                 for i in 0..graph.num_demes_in_model() {
                     if selfing_rates[i] > 0.0 {
                         assert!(child_deme_sizes[i] > 0.0);


### PR DESCRIPTION
* ForwardGraph::ancestry_proportions now returns
  None if the deme is out of range.
* This change removes a potential panic.
